### PR TITLE
added MIBs for tx/rx db

### DIFF
--- a/include/config.pm
+++ b/include/config.pm
@@ -83,7 +83,12 @@ our @snmp_objects = [
 	['jnxVirtualChassisMemberRole'],
 	['jnxVirtualChassisMemberSerialnumber'],
 	['jnxVirtualChassisMemberSWVersion'],
-	['jnxVirtualChassisMemberUptime']
+	['jnxVirtualChassisMemberUptime'],
+	['jnxDomCurrentRxLaserPower'],
+	['jnxDomCurrentTxLaserOutputPower'],
+	['jnxPMCurRxInputPower'],
+	['jnxPMCurTxOutputPower']
+
 ];
 
 BEGIN {


### PR DESCRIPTION
Added MIBs for measuring Tx and Rx dBm levels on optics.
Two sets since it seems to depend on model of device/junos version.