### PR TITLE
Templating: New filter getIp, fixed errors in dhcp filters

### DIFF
--- a/ansible/roles/web/files/varnish.vcl
+++ b/ansible/roles/web/files/varnish.vcl
@@ -108,6 +108,11 @@ sub vcl_recv {
         return (pass);
     }
 
+    # exclude listing of template files
+    if (req.url ~ "/api/read/template-list" ) {
+        return (pass);
+    }
+
     # We don't use cookies - so get rid of them so we don't mess up the cache
     # by accident.
     unset req.http.Cookie;

--- a/extras/misc/varnish.vcl
+++ b/extras/misc/varnish.vcl
@@ -107,6 +107,11 @@ sub vcl_recv {
         return (pass);
     }
 
+    # exclude listing of template files
+    if (req.url ~ "/api/read/template-list" ) {
+        return (pass);
+    }
+
     # We don't use cookies - so get rid of them so we don't mess up the cache
     # by accident.
     unset req.http.Cookie;

--- a/templating/templating.py
+++ b/templating/templating.py
@@ -32,8 +32,9 @@ env = Environment(loader=FileSystemLoader([]), trim_blocks=True)
 env.filters["netmask"] = lambda ip: netaddr.IPNetwork(ip).netmask
 env.filters["cidr"] = lambda ip: netaddr.IPNetwork(ip).prefixlen
 env.filters["networkId"] = lambda ip: netaddr.IPNetwork(ip).ip
-env.filters["getFirstDhcpIp"] = lambda ip: netaddr.IPNetwork(ip)[3]
-env.filters["getLastDhcpIp"] = lambda ip: netaddr.IPNetwork(ip)[-1]
+env.filters["getFirstDhcpIp"] = lambda ip: netaddr.IPNetwork(ip)[2]
+env.filters["getLastDhcpIp"] = lambda ip: netaddr.IPNetwork(ip)[-2]
+env.filters["getIp"] = lambda ip,num: netaddr.IPNetwork(ip)[num]
 env.filters["agentDistro"] = lambda src: src.split(":")[0]
 env.filters["agentPort"] = lambda src: src.split(":")[1]
 env.filters["getFirstFapIP"] = lambda ip: netaddr.IPNetwork(ip)[netaddr.IPNetwork(ip).size / 2]


### PR DESCRIPTION
Created getIp to replace all cases of "getXIp" filters in the future.
getFirstDhcpIp got the secound DHCP IP. 
And getLastDhcpIp got the broadcast IP.

Fixed them.

getIp is required for the new TG19 distro template.

Edit:
I suck at git. So now this also includes a fix for varnish to not cache templating files. Branching is hard.