### PR TITLE
fix(nightmode): Respect user provided configuration for night mode if provided

### DIFF
--- a/web/js/nms-nightmode.js
+++ b/web/js/nms-nightmode.js
@@ -7,6 +7,11 @@ var nmsNightMode = nmsNightMode || {
 var prefersColorSchemeMediaQuery = "(prefers-color-scheme: dark)";
 
 nmsNightMode.toggle = function() {
+	if (nms.nightMode) {
+		console.log("nightmode already set, not following system (remove cookies & url param to re-enable system following)");
+		return
+	}
+
 	var active = window.matchMedia(prefersColorSchemeMediaQuery).matches;
 	nms.nightMode = active;
 }


### PR DESCRIPTION
If user sets the cookie or URL query parameter for nightMode, we will
respect that. Note that it is a bit cumbersome to _clear_ this
configuration (afaik?) if it is set.

This is also the case if the user toggles nightmode directly in Gondul
(`n`).
However, this last configuration is not persisted - so on a page reload,
this setting is removed (no need to clear cookies/query params), and
the system preference is again followed.
